### PR TITLE
fix: NLH 프리플랍 평가 패닉 및 베팅 라운드 종료 오류 수정, 테스트 추가

### DIFF
--- a/internal/game/run.go
+++ b/internal/game/run.go
@@ -267,17 +267,14 @@ func (g *Game) dealCommunityCards(n int) {
 // isBettingActionRequired checks if there is any pending bet that needs to be called.
 // The round can be skipped if all non-folded players have the same amount bet.
 func (g *Game) isBettingActionRequired() bool {
-	// If less than two players can even act (have chips and haven't folded), no betting can occur.
-	if g.CountPlayersAbleToAct() < 2 {
-		// However, we must check if the single active player needs to call a previous all-in.
-		for _, p := range g.Players {
-			if p.Status == PlayerStatusPlaying && p.CurrentBet < g.BetToCall {
-				return true // This player must act.
-			}
+	// If there is at least one player who can act and still needs to match the bet, betting is required.
+	for _, p := range g.Players {
+		if p.Status == PlayerStatusPlaying && p.CurrentBet < g.BetToCall {
+			return true
 		}
-		return false
 	}
-	return true
+	// Otherwise, no further betting action is required for this round.
+	return false
 }
 
 // PrepareNewBettingRound resets player bets and determines the starting player for a new round.


### PR DESCRIPTION
커서 GPT5로 수정했는데 에러 잘 잡아주는거 같습니다ㅋㅋ

- NLH(2장) 홀카드에서 발생한 인덱스 초과 패닉 방지를 위한 최소 가드 추가 (3장 로직 불변)
- 베팅 라운드 종료 판단 로직 수정(isBettingActionRequired) — 콜 필요 플레이어 존재 여부 기준
- 종료 조건과 프리플랍 Call/Call/Check 시 라운드 종료를 검증하는 테스트 추가

관련: nlh --outs 실행 시 패닉, 베팅 루프 무한 진행 버그